### PR TITLE
Fix typo in field labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,8 +210,8 @@ Following fields are included in the Copilot Usage Report
 - User
 - Created At
 - Updated At
-- Last Acivity At
-- Last Acivity Editor
+- Last Activity At
+- Last Activity Editor
 - Pending Cancellation Date
 - Team
 - Status - this field have the default value as 'pending_cancellation'. If the user is removed, this turned to 'deleted'

--- a/app/index.js
+++ b/app/index.js
@@ -35,11 +35,11 @@ const fields = [
         value: 'updated_at'
     },
     {
-        label: 'Last Acivity At',
+        label: 'Last Activity At',
         value: 'last_activity_at'
     },
     {
-        label: 'Last Acivity Editor',
+        label: 'Last Activity Editor',
         value: 'last_activity_editor'
     },
     {


### PR DESCRIPTION
Hi 👋 

This pull request includes corrections of typographical errors in the `README.md` and `app/index.js` files. The term "Acivity" has been corrected to "Activity" in both files.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L213-R214): Fixed typos in the `Following fields are included in the Copilot Usage Report` section. The terms "Last Acivity At" and "Last Acivity Editor" have been corrected to "Last Activity At" and "Last Activity Editor" respectively.
* [`app/index.js`](diffhunk://#diff-70b6a4ba131b90d3682f0b2ba111ccabb455e5584068bdfc9744f713f79db1a5L38-R42): Corrected the labels 'Last Acivity At' and 'Last Acivity Editor' to 'Last Activity At' and 'Last Activity Editor' in the `const fields = [` array. ([app/index.jsL38-R42](diffhunk://#diff-70b6a4ba131b90d3682f0b2ba111ccabb455e5584068bdfc9744f713f79db1a5L38-R42))